### PR TITLE
Make ESP8266 binary sensors identical to ESP32

### DIFF
--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -61,21 +61,53 @@ modbus_controller:
 
 binary_sensor:
   #  11  Status/Fault flag                     2 byte   R  uint16  Hex See ^3
-  #      Bit 8: Status: Charging enabled/disabled
+  #      Bit 8: Status: Charging operation
+  - platform: modbus_controller
+    modbus_controller_id: bms0
+    name: "${name} charging operation"
+    address: 11
+    register_type: holding
+    bitmask: 0x0100
+
+  #      Bit 9: Status: Discharging operation
+  - platform: modbus_controller
+    modbus_controller_id: bms0
+    name: "${name} discharging operation"
+    address: 11
+    register_type: holding
+    bitmask: 0x0200
+
+  #      Bit 10: Status: Charging enabled/disabled
   - platform: modbus_controller
     modbus_controller_id: bms0
     name: "${name} charging"
     address: 11
     register_type: holding
-    bitmask: 0x0080
+    bitmask: 0x0400
 
-  #      Bit 9: Status: Discharging enabled/disabled
+  #      Bit 11: Status: Discharging enabled/disabled
   - platform: modbus_controller
     modbus_controller_id: bms0
     name: "${name} discharging"
     address: 11
     register_type: holding
-    bitmask: 0x0100
+    bitmask: 0x0800
+
+  #      Bit 10: Status: Charging enabled/disabled
+  - platform: modbus_controller
+    modbus_controller_id: bms0
+    name: "${name} charging"
+    address: 11
+    register_type: holding
+    bitmask: 0x0400
+
+  #      Bit 11: Status: Discharging enabled/disabled
+  - platform: modbus_controller
+    modbus_controller_id: bms0
+    name: "${name} discharging"
+    address: 11
+    register_type: holding
+    bitmask: 0x0800
 
 sensor:
   #   0  Current                               2 byte   R   int16  10mA (Positive: chargingm Negative: discharging)


### PR DESCRIPTION
Fix ESP8266 binary charging sensors, so that they are identical to the ESP32 version