### PR TITLE
Drop duplicates

### DIFF
--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -93,22 +93,6 @@ binary_sensor:
     register_type: holding
     bitmask: 0x0800
 
-  #      Bit 10: Status: Charging enabled/disabled
-  - platform: modbus_controller
-    modbus_controller_id: bms0
-    name: "${name} charging"
-    address: 11
-    register_type: holding
-    bitmask: 0x0400
-
-  #      Bit 11: Status: Discharging enabled/disabled
-  - platform: modbus_controller
-    modbus_controller_id: bms0
-    name: "${name} discharging"
-    address: 11
-    register_type: holding
-    bitmask: 0x0800
-
   #  12  Balance status-bits per cell (1-16)   2 byte   R  uint16  Hex
   #      Bit 1: Status: Balancing cell 1
   - platform: modbus_controller


### PR DESCRIPTION
Fix for pull request #47 "Make ESP8266 binary sensors identical to ESP32"

The last two binary charging sensors was duplicated. 
Sorry for the mess. Looks ok in my commit though
¯\_(ツ)_/¯