### PR TITLE
Updated Protection "Reserve (Bit 16)" to "Battery Full"

### DIFF
--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -1686,7 +1686,7 @@ text_sensor:
           "MOSFET overtemperature",        // 0001 0000 0000 0000 (13)
           "Environment overtemperature",   // 0010 0000 0000 0000 (14)
           "Environment undertemperature",  // 0100 0000 0000 0000 (15)
-          "Reserve (Bit 16)",              // 1000 0000 0000 0000 (16)
+          "Battery Full",                  // 1000 0000 0000 0000 (16)
       };
       std::string values = "";
 


### PR DESCRIPTION
I have Pace P16S200A and had the "Reserve (Bit 16)". Figured out that this means battery Full has reached. Either the Full-Charge Current is lower than set (mine <500mA) or Full-Charge Voltage reached.