### PR TITLE
Fix HA disconnect caused by null bytes in ASCII register strings

### DIFF
--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -1788,6 +1788,8 @@ text_sensor:
     register_type: holding
     register_count: 10
     response_size: 20
+    lambda: |-
+      return x.substr(0, x.find('\0'));
 
   # 160  Model SN                             20 byte  RW  uint16  ASCII BMS Manufacturer
   - platform: modbus_controller
@@ -1798,6 +1800,8 @@ text_sensor:
     register_type: holding
     register_count: 10
     response_size: 20
+    lambda: |-
+      return x.substr(0, x.find('\0'));
 
   # 170  PACK SN                              20 byte  RW  uint16  ASCII PACK Manufacturer
   - platform: modbus_controller
@@ -1808,3 +1812,5 @@ text_sensor:
     register_type: holding
     register_count: 10
     response_size: 20
+    lambda: |-
+      return x.substr(0, x.find('\0'));

--- a/multiple-batteries-example/pack.yaml
+++ b/multiple-batteries-example/pack.yaml
@@ -1684,6 +1684,8 @@ text_sensor:
     register_type: holding
     register_count: 10
     response_size: 20
+    lambda: |-
+      return x.substr(0, x.find('\0'));
 
   # 160  Model SN                             20 byte  RW  uint16  ASCII BMS Manufacturer
   - platform: modbus_controller
@@ -1694,6 +1696,8 @@ text_sensor:
     register_type: holding
     register_count: 10
     response_size: 20
+    lambda: |-
+      return x.substr(0, x.find('\0'));
 
   # 170  PACK SN                              20 byte  RW  uint16  ASCII PACK Manufacturer
   - platform: modbus_controller
@@ -1704,3 +1708,5 @@ text_sensor:
     register_type: holding
     register_count: 10
     response_size: 20
+    lambda: |-
+      return x.substr(0, x.find('\0'));


### PR DESCRIPTION
## Summary

- ASCII text sensors reading 20-byte registers (version info, BMS SN, pack SN) can contain embedded null bytes when the actual value is shorter than 20 bytes
- The ESPHome API component cannot handle null bytes in string fields, causing Home Assistant to drop the connection (`CONNECTION_CLOSED errno=128`)
- Adds a lambda to each affected sensor that truncates the string at the first `\0` character — `x.substr(0, x.find('\0'))` is safe even when no null byte is present (`npos` substr returns the full string)

## Affected sensors

Both `esp32-example.yaml` and `multiple-batteries-example/pack.yaml`:
- Register 150: Version Information
- Register 160: BMS Serial Number
- Register 170: PACK Serial Number (Battery Pack Serial Number)

## Test plan

- [ ] Deploy config with a BMS that returns a short PACK SN (padded with `\0`)
- [ ] Verify ESPHome device stays connected to Home Assistant
- [ ] Verify sensor values are visible in HA

Fixes #83