### PR TITLE
Work around upstream modbus_controller offset bug causing wrong total voltage in ESPHome 2026.4.x

### DIFF
--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -247,7 +247,7 @@ sensor:
     address: 1
     register_type: holding
     value_type: U_WORD
-    # Workaround for esphome/esphome#11925 — remove once esphome/esphome#11781 is merged
+    # Workaround for syssi/esphome-pace-bms#90 / esphome/esphome#11925 - remove once esphome/esphome#11781 is merged
     force_new_range: true
     unit_of_measurement: "V"
     device_class: voltage

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -247,6 +247,8 @@ sensor:
     address: 1
     register_type: holding
     value_type: U_WORD
+    # Workaround for esphome/esphome#11925 — remove once esphome/esphome#11781 is merged
+    force_new_range: true
     unit_of_measurement: "V"
     device_class: voltage
     state_class: measurement

--- a/multiple-batteries-example/pack.yaml
+++ b/multiple-batteries-example/pack.yaml
@@ -181,6 +181,8 @@ sensor:
     address: 1
     register_type: holding
     value_type: U_WORD
+    # Workaround for esphome/esphome#11925 — remove once esphome/esphome#11781 is merged
+    force_new_range: true
     unit_of_measurement: "V"
     device_class: voltage
     state_class: measurement

--- a/multiple-batteries-example/pack.yaml
+++ b/multiple-batteries-example/pack.yaml
@@ -181,7 +181,7 @@ sensor:
     address: 1
     register_type: holding
     value_type: U_WORD
-    # Workaround for esphome/esphome#11925 — remove once esphome/esphome#11781 is merged
+    # Workaround for syssi/esphome-pace-bms#90 / esphome/esphome#11925 - remove once esphome/esphome#11781 is merged
     force_new_range: true
     unit_of_measurement: "V"
     device_class: voltage


### PR DESCRIPTION
## Problem

Total voltage reads incorrect values starting with ESPHome 2026.4.x. This is a confirmed upstream bug in `modbus_controller`'s `create_register_ranges_()` function: when two sensors share adjacent registers, the re-use path sets `curr->offset` without accounting for `prev->get_register_size()`, so the second sensor reads from the wrong position.

Upstream issue: [esphome/esphome#11925](https://github.com/esphome/esphome/issues/11925)
Upstream fix (in review): [esphome/esphome#11781](https://github.com/esphome/esphome/pull/11781)

## Workaround

Add `force_new_range: true` to the total voltage sensor. This skips the re-use/extend check entirely, giving the sensor its own independent register range with `offset = 0`, so it reads the correct register.

The added comment references the upstream issue so the workaround can be removed once the fix lands.

## TODO

Remove `force_new_range: true` and its comment from both `esp32-example.yaml` and `multiple-batteries-example/pack.yaml` once [esphome/esphome#11781](https://github.com/esphome/esphome/pull/11781) is merged and released.

Fixes #90