### PR TITLE
Handle 0xFF padding in ASCII register string sensors

### DIFF
--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -1792,7 +1792,7 @@ text_sensor:
     register_count: 10
     response_size: 20
     lambda: |-
-      return x.substr(0, x.find('\0'));
+      return x.substr(0, x.find_first_of(std::string("\x00\xff", 2)));
 
   # 160  Model SN                             20 byte  RW  uint16  ASCII BMS Manufacturer
   - platform: modbus_controller
@@ -1804,7 +1804,7 @@ text_sensor:
     register_count: 10
     response_size: 20
     lambda: |-
-      return x.substr(0, x.find('\0'));
+      return x.substr(0, x.find_first_of(std::string("\x00\xff", 2)));
 
   # 170  PACK SN                              20 byte  RW  uint16  ASCII PACK Manufacturer
   - platform: modbus_controller
@@ -1816,4 +1816,4 @@ text_sensor:
     register_count: 10
     response_size: 20
     lambda: |-
-      return x.substr(0, x.find('\0'));
+      return x.substr(0, x.find_first_of(std::string("\x00\xff", 2)));

--- a/multiple-batteries-example/pack.yaml
+++ b/multiple-batteries-example/pack.yaml
@@ -1687,7 +1687,7 @@ text_sensor:
     register_count: 10
     response_size: 20
     lambda: |-
-      return x.substr(0, x.find('\0'));
+      return x.substr(0, x.find_first_of(std::string("\x00\xff", 2)));
 
   # 160  Model SN                             20 byte  RW  uint16  ASCII BMS Manufacturer
   - platform: modbus_controller
@@ -1699,7 +1699,7 @@ text_sensor:
     register_count: 10
     response_size: 20
     lambda: |-
-      return x.substr(0, x.find('\0'));
+      return x.substr(0, x.find_first_of(std::string("\x00\xff", 2)));
 
   # 170  PACK SN                              20 byte  RW  uint16  ASCII PACK Manufacturer
   - platform: modbus_controller
@@ -1711,4 +1711,4 @@ text_sensor:
     register_count: 10
     response_size: 20
     lambda: |-
-      return x.substr(0, x.find('\0'));
+      return x.substr(0, x.find_first_of(std::string("\x00\xff", 2)));


### PR DESCRIPTION
## Summary

- Some BMS variants (e.g. Docan Panda KS48200-Ho21_V2) pad 20-byte ASCII registers with `0xFF` instead of null bytes (`\0`)
- The previous fix (#93) only stripped `\0`, so `0xFF` bytes remained in the string value — causing the same HA disconnect (`CONNECTION_CLOSED errno=128`)
- Replace `x.find('\0')` with `x.find_first_of(std::string("\x00\xff", 2))` to truncate at whichever terminator appears first
- `npos` behavior is identical: if neither byte is found the full string is returned unchanged

## Affected files

- `esp32-example.yaml` — registers 150, 160, 170
- `multiple-batteries-example/pack.yaml` — registers 150, 160, 170

Fixes #83