### PR TITLE
Mark ASCII string sensors as diagnostic entity category

### DIFF
--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -1786,6 +1786,7 @@ text_sensor:
   - platform: modbus_controller
     modbus_controller_id: bms0
     name: "version information"
+    entity_category: diagnostic
     skip_updates: 60
     address: 150
     register_type: holding
@@ -1798,6 +1799,7 @@ text_sensor:
   - platform: modbus_controller
     modbus_controller_id: bms0
     name: "bms serial number"
+    entity_category: diagnostic
     skip_updates: 60
     address: 160
     register_type: holding
@@ -1810,6 +1812,7 @@ text_sensor:
   - platform: modbus_controller
     modbus_controller_id: bms0
     name: "battery pack serial number"
+    entity_category: diagnostic
     skip_updates: 60
     address: 170
     register_type: holding

--- a/multiple-batteries-example/pack.yaml
+++ b/multiple-batteries-example/pack.yaml
@@ -1681,6 +1681,7 @@ text_sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
     name: "${friendly_name} ${pack} Version Information"
+    entity_category: diagnostic
     skip_updates: 60
     address: 150
     register_type: holding
@@ -1693,6 +1694,7 @@ text_sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
     name: "${friendly_name} ${pack} BMS Serial Number"
+    entity_category: diagnostic
     skip_updates: 60
     address: 160
     register_type: holding
@@ -1705,6 +1707,7 @@ text_sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
     name: "${friendly_name} ${pack} Battery Serial Number"
+    entity_category: diagnostic
     skip_updates: 60
     address: 170
     register_type: holding


### PR DESCRIPTION
## Summary

- Version information, BMS serial number, and battery pack serial number are static metadata, not measurements
- Mark them as `entity_category: diagnostic` so Home Assistant hides them from the default entity list and groups them under the diagnostic section

## Affected files

- `esp32-example.yaml` -- registers 150, 160, 170
- `multiple-batteries-example/pack.yaml` -- registers 150, 160, 170