### PR TITLE
Batch consecutive reserved register reads to reduce Modbus bus traffic

### DIFF
--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -345,6 +345,7 @@ sensor:
     name: "charging cycles"
     address: 7
     register_type: holding
+    register_count: 2
     value_type: U_WORD
     unit_of_measurement: ""
     state_class: measurement
@@ -391,6 +392,7 @@ sensor:
     name: "balancer status"
     address: 12
     register_type: holding
+    register_count: 3
     value_type: U_WORD
     unit_of_measurement: ""
     state_class: measurement

--- a/multiple-batteries-example/pack.yaml
+++ b/multiple-batteries-example/pack.yaml
@@ -279,6 +279,7 @@ sensor:
     name: "${friendly_name} ${pack} Charging Cycles"
     address: 7
     register_type: holding
+    register_count: 2
     value_type: U_WORD
     unit_of_measurement: ""
     state_class: measurement
@@ -323,6 +324,7 @@ sensor:
     name: "${friendly_name} ${pack} Balancer Status"
     address: 12
     register_type: holding
+    register_count: 3
     value_type: U_WORD
     unit_of_measurement: ""
     state_class: measurement


### PR DESCRIPTION
## Summary

- Register 7 (charging cycles) is followed by register 8 (reserved) -- batching them into one request with `register_count: 2` saves one round-trip per poll cycle
- Register 12 (balancer status) is followed by registers 13 and 14 (both reserved) -- batching with `register_count: 3` saves two round-trips per poll cycle
- Fewer individual Modbus requests reduce bus load and improve stability, particularly on single-core ESP32 devices at high poll rates

## Affected files

- `esp32-example.yaml` -- registers 7 and 12
- `multiple-batteries-example/pack.yaml` -- registers 7 and 12